### PR TITLE
Modify NVRTC compiler arguments for profiling workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ exts/omni.warp/config/extension.gen.toml
 .coverage
 .cache
 warp/tests/outputs
+warp_source_cache/
+
 
 # CUTLASS repo directories we don't want to track
 warp/native/cutlass/.github

--- a/build_lib.py
+++ b/build_lib.py
@@ -72,12 +72,6 @@ parser.add_argument("--standalone", action="store_true", help="Use standalone LL
 parser.add_argument("--no_standalone", dest="standalone", action="store_false")
 parser.set_defaults(standalone=True)
 
-
-## Custom additions
-parser.add_argument("--lineinfo", action="store_true", help="Generate line-number information for device code at compilation")
-parser.set_defaults(lineinfo=False)
-
-
 args = parser.parse_args()
 
 # set build output path off this file

--- a/build_lib.py
+++ b/build_lib.py
@@ -73,6 +73,11 @@ parser.add_argument("--no_standalone", dest="standalone", action="store_false")
 parser.set_defaults(standalone=True)
 
 
+## Custom additions
+parser.add_argument("--lineinfo", action="store_true", help="Generate line-number information for device code at compilation")
+parser.set_defaults(lineinfo=False)
+
+
 args = parser.parse_args()
 
 # set build output path off this file

--- a/profile.sh
+++ b/profile.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Get the directory where the script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export WARP_CACHE_PATH="$SCRIPT_DIR/warp_source_cache/"
+
+echo "Kernel written to $WARP_CACHE_PATH"
+
+ncu --set full --target-processes all \
+    --metrics dram__bytes_read.sum,dram__bytes_written.sum,sm__inst_executed_pipe_tensor_op_hmma.avg,sm__cycles_elapsed.avg,l2_tex_read_bytes.sum,l2_tex_write_bytes.sum,lts__t_bytes.sum,lts__t_sectors_pipe_lsu_mem_rd.sum,lts__t_sectors_pipe_lsu_mem_wr.sum \
+    --nvtx --call-stack \
+    --export _warp_test_run -f \
+    --import-source yes \
+    --source-folders $WARP_CACHE_PATH \
+    python test.py 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,30 @@
+import warp as wp
+import numpy as np
+
+num_points = 1024
+
+@wp.kernel
+def length(points: wp.array(dtype=wp.vec3),
+           lengths: wp.array(dtype=float)):
+
+    # thread index
+    tid = wp.tid()
+    
+    # compute distance of each point from origin
+    lengths[tid] = wp.length(points[tid])
+
+
+# allocate an array of 3d points
+points = wp.array(np.random.rand(num_points, 3), dtype=wp.vec3)
+lengths = wp.zeros(num_points, dtype=float)
+
+# launch kernel
+wp.launch(kernel=length,
+          dim=len(points),
+          inputs=[points, lengths])
+
+
+np_lengths = np.linalg.norm(points.numpy(), 2, axis=-1)
+
+assert np.allclose(lengths.numpy(), np_lengths), "Values do not match."
+print("Sanity check completed successfully.")

--- a/test.py
+++ b/test.py
@@ -1,15 +1,18 @@
-import warp as wp
 import numpy as np
+
+import warp as wp
+
+wp.clear_kernel_cache()
+# wp.init()
 
 num_points = 1024
 
-@wp.kernel
-def length(points: wp.array(dtype=wp.vec3),
-           lengths: wp.array(dtype=float)):
 
+@wp.kernel
+def length(points: wp.array(dtype=wp.vec3), lengths: wp.array(dtype=float)):
     # thread index
     tid = wp.tid()
-    
+
     # compute distance of each point from origin
     lengths[tid] = wp.length(points[tid])
 
@@ -19,12 +22,11 @@ points = wp.array(np.random.rand(num_points, 3), dtype=wp.vec3)
 lengths = wp.zeros(num_points, dtype=float)
 
 # launch kernel
-wp.launch(kernel=length,
-          dim=len(points),
-          inputs=[points, lengths])
-
+wp.launch(kernel=length, dim=len(points), inputs=[points, lengths])
 
 np_lengths = np.linalg.norm(points.numpy(), 2, axis=-1)
 
-assert np.allclose(lengths.numpy(), np_lengths), "Values do not match."
+assert np.allclose(
+    lengths.numpy(), np_lengths
+), f"Numpy and Warp outputs do not match: {lengths.numpy()} vs {np_lengths}"
 print("Sanity check completed successfully.")

--- a/warp/build_dll.py
+++ b/warp/build_dll.py
@@ -212,20 +212,16 @@ def build_dll_for_arch(args, dll_path, cpp_paths, cu_path, libs, arch, mode=None
                     "-gencode=arch=compute_86,code=compute_86",
                 ]
 
-
         ######## Custom additions ########
-        gcc_option = ["-ccbin g++-11"]  # force compatible gcc version for CUDA 12.6
+        gcc_option = ["-ccbin g++-11"]  # force compatible gcc version for CUDA 12.6 local build
         gencode_opts += gcc_option
-        
-        if args.lineinfo:
-            gencode_opts.append("--generate-line-info")
-        
+
         ###################################
 
         nvcc_opts = gencode_opts + [
             "-t0",  # multithreaded compilation
             "--extended-lambda",
-        ]        
+        ]
 
         if args.fast_math:
             nvcc_opts.append("--use_fast_math")

--- a/warp/build_dll.py
+++ b/warp/build_dll.py
@@ -212,10 +212,20 @@ def build_dll_for_arch(args, dll_path, cpp_paths, cu_path, libs, arch, mode=None
                     "-gencode=arch=compute_86,code=compute_86",
                 ]
 
+
+        ######## Custom additions ########
+        gcc_option = ["-ccbin g++-11"]  # force compatible gcc version for CUDA 12.6
+        gencode_opts += gcc_option
+        
+        if args.lineinfo:
+            gencode_opts.append("--generate-line-info")
+        
+        ###################################
+
         nvcc_opts = gencode_opts + [
             "-t0",  # multithreaded compilation
             "--extended-lambda",
-        ]
+        ]        
 
         if args.fast_math:
             nvcc_opts.append("--use_fast_math")

--- a/warp/context.py
+++ b/warp/context.py
@@ -1960,6 +1960,7 @@ class Module:
 
             # final object binary path
             binary_path = os.path.join(module_dir, output_name)
+            print(f"\nCOMPILED BINARY SAVED IN: {binary_path}\n")
 
             # -----------------------------------------------------------
             # check cache and build if necessary

--- a/warp/context.py
+++ b/warp/context.py
@@ -1960,7 +1960,6 @@ class Module:
 
             # final object binary path
             binary_path = os.path.join(module_dir, output_name)
-            print(f"\nCOMPILED BINARY SAVED IN: {binary_path}\n")
 
             # -----------------------------------------------------------
             # check cache and build if necessary

--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -2667,7 +2667,7 @@ size_t cuda_compile_program(const char* cuda_src, int arch, const char* include_
     if (debug)
     {
         opts.push_back("--define-macro=_DEBUG");
-        opts.push_back("--generate-line-info");
+        // opts.push_back("--generate-line-info");
         // disabling since it causes issues with `Unresolved extern function 'cudaGetParameterBufferV2'
         //opts.push_back("--device-debug");
     }
@@ -2703,7 +2703,7 @@ size_t cuda_compile_program(const char* cuda_src, int arch, const char* include_
         opts.push_back("--relocatable-device-code=true");
     }
 
-    opts.push_back("--generate-line-info");   // TODO clean up as part of config.py (e.g. deduplicate when mode=debug)
+    opts.push_back("--generate-line-info");  // Always enable to allow profiling
 
     nvrtcProgram prog;
     nvrtcResult res;

--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -2703,13 +2703,15 @@ size_t cuda_compile_program(const char* cuda_src, int arch, const char* include_
         opts.push_back("--relocatable-device-code=true");
     }
 
+    opts.push_back("--generate-line-info");   // TODO clean up as part of config.py (e.g. deduplicate when mode=debug)
+
     nvrtcProgram prog;
     nvrtcResult res;
 
     res = nvrtcCreateProgram(
         &prog,         // prog
         cuda_src,      // buffer
-        NULL,          // name
+        "module_codegen.cu",  // name (replace from NULL for profiler to recognize source)
         0,             // numHeaders
         NULL,          // headers
         NULL);         // includeNames


### PR DESCRIPTION
Warp uses NVRTC to compile a kernel, generated via `codegen.py` from python source code, during runtime. Since the source code for nvrtc compilation is a raw string and not a file, NSight Compute cannot associate the kernel with any source file. Note that, if we were using NVCC, `--generate-line-info` suffices to associate the program to its source file's code line-by-line, but in our case, given no filename to associate, the profiler can't do anything with the line number information.

This PR enables local build of Warp on CUDA 12.6, and modifies `nvrtcCreateProgram` such that the kernel is (1) always compiled with `--generate-line-info`, (2) and associated with a `module_codegen.cu`, which is a cache file that Warp copies the raw code string into (and invokes, via a utf-8 encoded function signature, during execution context). 

In short, a Warp kernel is now compiled in a way such that profilers like Nsight Compute can generate source-to-assembly comparison views:
![image](https://github.com/user-attachments/assets/a12105ad-fe7a-4bdc-8410-13885008666b)



**Remaining TODOs:**
 - Write function that returns cache directory name for a given Warp kernel. (Should be some deterministic function of the module/file/kernel name, and one or more of those names' utf-8 encoding.) With this functionality, we can automate the `ncu` workflow to recognize the `--source-folders` without having to compile the kernel first to initialize the cache directory. See the print statement in `context.py`
 - Make "Profiling Mode" a field in `config.py` such that `--generate-line-info` and potential future customizations can be toggled easily in one argument.